### PR TITLE
Add new Class for column left and right

### DIFF
--- a/app/css/esp.css
+++ b/app/css/esp.css
@@ -30,7 +30,7 @@
   font-style: normal;
 }
 
-body { 
+body {
   font-family: "Roboto", sans-serif;
   font-weight: 400;
 }
@@ -51,7 +51,7 @@ a {
   color: #e59925;
   text-decoration: none;
 }
-  
+
 .remark-container {
   background-color: #111;
 }
@@ -115,15 +115,83 @@ p img {
   border-radius: .5em;
 }
 
-.remark-code, 
+.remark-code,
 .remark-inline-code {
   background-color: #1e262b;
   color: #2db59e;
-  font-family: monospace; 
+  font-family: monospace;
 }
 
 .remark-inline-code {
   padding: .1em .25em;
   margin: -.1em 0;
   border-radius: .25em;
+}
+
+/* Two-column layouts */
+.left-column  {
+  width: 49%;
+  float: left;
+}
+
+.left-column > img {
+  max-width: 100%;
+  max-height: 64vh;
+}
+
+.right-column {
+  width: 49%;
+  float: right;
+}
+
+.right-column > img {
+  max-width: 100%;
+  max-height: 64vh;
+}
+
+.left-column-33  {
+  width: 33%;
+  float: left;
+}
+
+.left-column-33 > img {
+  max-width: 100%;
+  max-height: 64vh;
+}
+
+.right-column-66 {
+  width: 66%;
+  float: right;
+}
+
+.right-column-66 > img {
+  max-width: 100%;
+  max-height: 64vh;
+}
+
+.left-column-66  {
+  width: 66%;
+  float: left;
+}
+
+.left-column-66 > img {
+  max-width: 100%;
+}
+
+.right-column-33 {
+  width: 33%;
+  float: right;
+}
+
+.right-column-33 > img {
+  max-width: 100%;
+  max-height: 64vh;
+}
+
+.right-column ~ p {
+  clear: both;
+}
+
+.right-column ~ ul {
+  clear: both;
 }


### PR DESCRIPTION
Add new classes `.left-column` and `.right-column` to support left and right columns.

You can use it like that:
- For 2 columns 50% width each =>
`.left-column[TEXT HERE]` and `.right-column[TEXT HERE]`

- For 2 columns 33% and 66% width =>
`.left-column-33[TEXT HERE]` and `.right-column-66[TEXT HERE]`
or
`.left-column-66[TEXT HERE]` and `.right-column-33[TEXT HERE]`